### PR TITLE
chore(JSOnlyQuickstart): sync auth files with docs verbatim

### DIFF
--- a/JSOnlyQuickstart/app/(auth)/_layout.tsx
+++ b/JSOnlyQuickstart/app/(auth)/_layout.tsx
@@ -1,5 +1,5 @@
-import { Redirect, Stack } from 'expo-router'
 import { useAuth } from '@clerk/expo'
+import { Redirect, Stack } from 'expo-router'
 
 export default function AuthRoutesLayout() {
   const { isSignedIn, isLoaded } = useAuth()

--- a/JSOnlyQuickstart/app/(auth)/sign-in.tsx
+++ b/JSOnlyQuickstart/app/(auth)/sign-in.tsx
@@ -26,13 +26,14 @@ export default function Page() {
     if (signIn.status === 'complete') {
       await signIn.finalize({
         navigate: ({ session, decorateUrl }) => {
+          // Handle session tasks
+          // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
           if (session?.currentTask) {
-            // Handle pending session tasks
-            // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
             console.log(session?.currentTask)
             return
           }
 
+          // If no session tasks, navigate the signed-in user to the home page
           const url = decorateUrl('/')
           if (url.startsWith('http')) {
             window.location.href = url
@@ -46,7 +47,9 @@ export default function Page() {
     } else if (signIn.status === 'needs_client_trust') {
       // For other second factor strategies,
       // see https://clerk.com/docs/guides/development/custom-flows/authentication/client-trust
-      const emailCodeFactor = signIn.supportedSecondFactors.find((factor) => factor.strategy === 'email_code')
+      const emailCodeFactor = signIn.supportedSecondFactors.find(
+        (factor) => factor.strategy === 'email_code',
+      )
 
       if (emailCodeFactor) {
         await signIn.mfa.sendEmailCode()
@@ -63,13 +66,14 @@ export default function Page() {
     if (signIn.status === 'complete') {
       await signIn.finalize({
         navigate: ({ session, decorateUrl }) => {
+          // Handle session tasks
+          // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
           if (session?.currentTask) {
-            // Handle pending session tasks
-            // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
             console.log(session?.currentTask)
             return
           }
 
+          // If no session tasks, navigate the signed-in user to the home page
           const url = decorateUrl('/')
           if (url.startsWith('http')) {
             window.location.href = url
@@ -87,7 +91,9 @@ export default function Page() {
   if (signIn.status === 'needs_client_trust') {
     return (
       <ThemedView style={styles.container}>
-        <ThemedText type="title" style={[styles.title, { fontSize: 24, fontWeight: 'bold' }]}>Verify your account</ThemedText>
+        <ThemedText type="title" style={[styles.title, { fontSize: 24, fontWeight: 'bold' }]}>
+          Verify your account
+        </ThemedText>
         <TextInput
           style={styles.input}
           value={code}
@@ -96,7 +102,9 @@ export default function Page() {
           onChangeText={(code) => setCode(code)}
           keyboardType="numeric"
         />
-        {errors.fields.code && <ThemedText style={styles.error}>{errors.fields.code.message}</ThemedText>}
+        {errors.fields.code && (
+          <ThemedText style={styles.error}>{errors.fields.code.message}</ThemedText>
+        )}
         <Pressable
           style={({ pressed }) => [
             styles.button,

--- a/JSOnlyQuickstart/app/(auth)/sign-up.tsx
+++ b/JSOnlyQuickstart/app/(auth)/sign-up.tsx
@@ -35,13 +35,14 @@ export default function Page() {
       await signUp.finalize({
         // Redirect the user to the home page after signing up
         navigate: ({ session, decorateUrl }) => {
+          // Handle session tasks
+          // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
           if (session?.currentTask) {
-            // Handle pending session tasks
-            // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
             console.log(session?.currentTask)
             return
           }
 
+          // If no session tasks, navigate the signed-in user to the home page
           const url = decorateUrl('/')
           if (url.startsWith('http')) {
             window.location.href = url

--- a/JSOnlyQuickstart/app/(home)/_layout.tsx
+++ b/JSOnlyQuickstart/app/(home)/_layout.tsx
@@ -1,5 +1,5 @@
-import { Redirect, Stack } from 'expo-router'
 import { useAuth } from '@clerk/expo'
+import { Redirect, Stack } from 'expo-router'
 
 export default function Layout() {
   const { isSignedIn, isLoaded } = useAuth()


### PR DESCRIPTION
## Summary

Aligns `JSOnlyQuickstart` byte-for-byte with the code blocks in the Clerk Expo JS quickstart docs (`clerk/clerk-docs` `main`). After clerk/clerk-docs#3278 fixed the docs path that deleted the `components/` directory, I checked whether the example app matched what someone now produces by following the docs end-to-end — it didn't, in four small ways:

- **`app/(auth)/sign-in.tsx`** — session-task comments were inside the `if (session?.currentTask)` block instead of above it; missing the `// If no session tasks, navigate the signed-in user to the home page` fallback comment (2 occurrences). `signIn.supportedSecondFactors.find(...)` was on a single 110-char line. The `<ThemedText type="title">Verify your account</ThemedText>` and `{errors.fields.code && <ThemedText…/>}` JSX were inlined where the docs wrap them.
- **`app/(auth)/sign-up.tsx`** — same session-task comment placement, single occurrence in `handleVerify`.
- **`app/(auth)/_layout.tsx`** and **`app/(home)/_layout.tsx`** — `expo-router` import was above `@clerk/expo`; docs alphabetize by source so `@clerk/expo` comes first.

No behavior change. The example app should be byte-equivalent to the docs path so any future docs drift surfaces here too.

## Verification

Extracted the code blocks from `docs/_partials/expo/email-pass-sign-in.mdx` and `email-pass-sign-up.mdx` on `clerk/clerk-docs` `main`, then `diff -u` against the updated quickstart files — zero differences. The two layout files match the inline snippets in `docs/getting-started/quickstart.expo.mdx`.

## Out of scope

`JSWithNativeSignInQuickstart` and `NativeComponentQuickstart` likely have their own drift vs the JS+Native and Native components doc tabs — worth a follow-up audit, kept out of this PR to keep the diff small and focused on the file Jordan's bug pointed at.