### PR TITLE
Remove unused .npmrc

### DIFF
--- a/JSOnlyQuickstart/.npmrc
+++ b/JSOnlyQuickstart/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/

--- a/JSWithNativeSignInQuickstart/.npmrc
+++ b/JSWithNativeSignInQuickstart/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/

--- a/NativeComponentQuickstart/.npmrc
+++ b/NativeComponentQuickstart/.npmrc
@@ -1,1 +1,0 @@
-registry=http://localhost:4873/


### PR DESCRIPTION
I tried to run the native component quickstart and all npm installs were failing. Turns out, this is set in `.npmrc`:

```
registry=http://localhost:4873/
```