### PR TITLE
Point Device Trust custom-flow links at the renamed guide

### DIFF
--- a/JSOnlyQuickstart/app/(auth)/sign-in.tsx
+++ b/JSOnlyQuickstart/app/(auth)/sign-in.tsx
@@ -45,7 +45,7 @@ export default function Page() {
       // See https://clerk.com/docs/guides/development/custom-flows/authentication/multi-factor-authentication
     } else if (signIn.status === 'needs_client_trust') {
       // For other second factor strategies,
-      // see https://clerk.com/docs/guides/development/custom-flows/authentication/client-trust
+      // see https://clerk.com/docs/guides/development/custom-flows/authentication/device-trust
       const emailCodeFactor = signIn.supportedSecondFactors.find((factor) => factor.strategy === 'email_code')
 
       if (emailCodeFactor) {

--- a/JSWithNativeSignInQuickstart/app/(auth)/sign-in.tsx
+++ b/JSWithNativeSignInQuickstart/app/(auth)/sign-in.tsx
@@ -47,7 +47,7 @@ export default function Page() {
       // See https://clerk.com/docs/guides/development/custom-flows/authentication/multi-factor-authentication
     } else if (signIn.status === 'needs_client_trust') {
       // For other second factor strategies,
-      // see https://clerk.com/docs/guides/development/custom-flows/authentication/client-trust
+      // see https://clerk.com/docs/guides/development/custom-flows/authentication/device-trust
       const emailCodeFactor = signIn.supportedSecondFactors.find((factor) => factor.strategy === 'email_code')
 
       if (emailCodeFactor) {


### PR DESCRIPTION
Part of [PROT-875](https://linear.app/clerk/issue/PROT-875/fully-rename-client-trust-to-device-trust).

## What

The "Client Trust" custom-flow guide is being renamed to "Device Trust" and moved to `/docs/guides/development/custom-flows/authentication/device-trust`. This updates the reference comment in both quickstart variants to point at the new slug.

- `JSOnlyQuickstart/app/(auth)/sign-in.tsx`
- `JSWithNativeSignInQuickstart/app/(auth)/sign-in.tsx`

## The `needs_client_trust` checks are deliberately unchanged

Per Kyle in the naming thread: _"we don't have to change APIs but the way we discuss clients externally should flip to devices."_ The status value keeps its name — renaming it would break existing custom sign-in flows. **Only the two comment URLs change.**

## Merge timing

The old URL will keep working either way (the docs PR ships a redirect for it), but the new `/device-trust` URL 404s until clerk/clerk#3051 deploys. Worth landing this after that deploy so the comment points somewhere live.

## Related

- clerk/clerk#3051 — docs + marketing (approved; landing as part of a combined typedoc sync PR)
- clerk/javascript#9266 — JSDoc (merged)
- clerk/dashboard#9839 — dashboard UI labels
- clerk/clerk_go#20787, clerk/skills#59
- Companion PRs: clerk-ios#540, clerk-android#858